### PR TITLE
fix: add missing createTokenAwareRetry and fix PR creation workflow

### DIFF
--- a/.github/scripts/github-api-with-retry.js
+++ b/.github/scripts/github-api-with-retry.js
@@ -113,8 +113,51 @@ async function paginateWithRetry(github, method, params, options = {}) {
   );
 }
 
+/**
+ * Token-aware retry factory for GitHub API calls.
+ *
+ * Returns an object with the Octokit client and retry helpers that pass the
+ * client through to callbacks, matching the calling convention used by all
+ * workflow scripts (e.g., `withRetry((client) => client.rest.issues.get(…))`).
+ *
+ * @param {Object} opts
+ * @param {Object} opts.github - Octokit instance from actions/github-script
+ * @param {Object} [opts.core] - Core helpers from actions/github-script
+ * @param {Object} [opts.env] - Environment variables (process.env)
+ * @param {string} [opts.task] - Label for logging
+ * @param {string[]} [opts.capabilities] - Required token capabilities
+ * @param {number} [opts.minRemaining] - Minimum remaining rate-limit budget
+ * @returns {Promise<{github: Object, withRetry: Function, paginateWithRetry: Function}>}
+ */
+async function createTokenAwareRetry(opts = {}) {
+  const { github: client, task } = opts;
+  if (!client) {
+    throw new Error('createTokenAwareRetry: github (Octokit) instance is required');
+  }
+  if (task) {
+    console.log(`[token-aware-retry] Initialised for task: ${task}`);
+  }
+
+  // Token-aware withRetry: passes the client to the callback so callers can
+  // write `withRetry((api) => api.rest.issues.get(…))`.
+  const tokenAwareWithRetry = (fn, options = {}) =>
+    withRetry(() => fn(client), options);
+
+  // Token-aware paginateWithRetry: delegates to the base implementation using
+  // the bound client.
+  const tokenAwarePaginateWithRetry = (method, params, options = {}) =>
+    paginateWithRetry(client, method, params, options);
+
+  return {
+    github: client,
+    withRetry: tokenAwareWithRetry,
+    paginateWithRetry: tokenAwarePaginateWithRetry,
+  };
+}
+
 module.exports = {
   withRetry,
   paginateWithRetry,
-  sleep
+  sleep,
+  createTokenAwareRetry,
 };

--- a/.github/workflows/agents-issue-intake.yml
+++ b/.github/workflows/agents-issue-intake.yml
@@ -179,7 +179,7 @@ jobs:
     if: |
       needs.route.outputs.should_run_bridge == 'true' &&
       needs.check_labels.outputs.should_run == 'true'
-    uses: stranske/Workflows/.github/workflows/reusable-agents-issue-bridge.yml@main
+    uses: ./.github/workflows/reusable-agents-issue-bridge.yml
     with:
       agent: ${{ needs.check_labels.outputs.agent }}
       issue_number: ${{ needs.check_labels.outputs.issue_number }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ test = [
     "pytest>=7.4",
     "pytest-cov>=4.1",
 ]
+langchain = [
+    "langchain-openai>=0.1.0",
+    "langchain-core>=0.2.0",
+]
 dev = [
     "pytest==9.0.2",
     "pytest-cov==7.0.0",


### PR DESCRIPTION
- Add createTokenAwareRetry function to github-api-with-retry.js. This function was required by 8+ workflow files (including the reusable issue bridge) but was missing, causing TypeError crashes that prevented branch/PR creation on issue intake.

- Fix agents-issue-intake.yml to use local reusable bridge instead of non-existent remote reference at stranske/Workflows.

- Add langchain optional dependency group to pyproject.toml so the capability check workflow can install langchain-openai properly.

https://claude.ai/code/session_019vQPm7hnVQD9oaLCa7aK4w